### PR TITLE
add value type(like int or float) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ HELLO_PARSER ={
             "nargs": 0,
             "action": "store_true",
             "default": False
+        },
+        {
+            "name": "repeat",
+            "type" : "optional",
+            "help": "repeat for N times",
+            "cmd_arg": [
+                "-r",
+                "--repeat"
+            ],
+            "nargs": 1,
+            "default": 1,
+            "valueType": int,
         }
 
     ]
@@ -64,9 +76,11 @@ def main(args):
     parsed_options = helloDargParser.parse_args(args)
     now = datetime.now()
     if parsed_options.printDate:
-        print "Hello %s! the time now is %s" % (parsed_options.yourName,now)
+        msg = "Hello %s! the time now is %s" % (parsed_options.yourName,now)
     else:
-        print "Hello %s!" % (parsed_options.yourName)
+        msg = "Hello %s!" % (parsed_options.yourName)
+    print '\n'.join([msg] * parsed_options.repeat)
+
 
 ###############################################################################
 ########################                   ####################################
@@ -109,6 +123,12 @@ Hello abdul!
 
 [abdul:~/objectlabs/dargparse] ./hello-dargeparse -d abdul
 Hello abdul! the time now is 2012-03-20 00:32:04.129220
+
+
+[abdul:~/objectlabs/dargparse] ./hello-dargeparse -d -r 3 abdul
+Hello abdul! the time now is 2012-03-20 00:32:05.496178
+Hello abdul! the time now is 2012-03-20 00:32:05.496178
+Hello abdul! the time now is 2012-03-20 00:32:05.496178
 
 
 [abdul:~/objectlabs/dargparse] ./hello-dargeparse -printDate abdul

--- a/dargparse/dargparse.py
+++ b/dargparse/dargparse.py
@@ -117,7 +117,7 @@ def make_arg_kwargs(arg_def):
 
     nargs = get_document_property(arg_def, "nargs")
     action = get_document_property(arg_def, "action")
-    arg_type = get_document_property(arg_def, "arg_type")
+    value_type = get_document_property(arg_def, "valueType")
 
     if nargs is not None:
         if nargs == 0:
@@ -128,8 +128,8 @@ def make_arg_kwargs(arg_def):
     if action is not None:
         kwargs["action"] = action
 
-    if arg_type is not None:
-        kwargs["type"] = arg_type
+    if value_type is not None:
+        kwargs["type"] = value_type
 
     default = get_document_property(arg_def, "default")
 

--- a/dargparse/dargparse.py
+++ b/dargparse/dargparse.py
@@ -117,6 +117,7 @@ def make_arg_kwargs(arg_def):
 
     nargs = get_document_property(arg_def, "nargs")
     action = get_document_property(arg_def, "action")
+    arg_type = get_document_property(arg_def, "arg_type")
 
     if nargs is not None:
         if nargs == 0:
@@ -126,6 +127,9 @@ def make_arg_kwargs(arg_def):
 
     if action is not None:
         kwargs["action"] = action
+
+    if arg_type is not None:
+        kwargs["type"] = arg_type
 
     default = get_document_property(arg_def, "default")
 

--- a/hello-dargeparse
+++ b/hello-dargeparse
@@ -57,6 +57,18 @@ HELLO_PARSER ={
             "nargs": 0,
             "action": "store_true",
             "default": False
+        },
+        {
+            "name": "repeat",
+            "type" : "optional",
+            "help": "repeat for N times",
+            "cmd_arg": [
+                "-r",
+                "--repeat"
+            ],
+            "nargs": 1,
+            "default": 1,
+            "valueType": int,
         }
 
     ]
@@ -78,9 +90,11 @@ def main(args):
     parsed_options = helloDargParser.parse_args(args)
     now = datetime.now()
     if parsed_options.printDate:
-        print "Hello %s! the time now is %s" % (parsed_options.yourName,now)
+        msg = "Hello %s! the time now is %s" % (parsed_options.yourName,now)
     else:
-        print "Hello %s!" % (parsed_options.yourName)
+        msg = "Hello %s!" % (parsed_options.yourName)
+    print '\n'.join([msg] * parsed_options.repeat)
+
 
 ###############################################################################
 ########################                   ####################################


### PR DESCRIPTION
ref: http://docs.python.org/dev/library/argparse.html#type unfortunately, the name "type" is already used in dargparse to distinguish "optional" and "positional" arguments, so "arg_type" is used instead for the sake of backward compatibility.
